### PR TITLE
Add random value to signature tied to session

### DIFF
--- a/web/app/context/VoterContext.tsx
+++ b/web/app/context/VoterContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, FC, useContext, useEffect, useState } from "react";
-import { createSignatureMessage } from "../lib/auth";
+import { createSignatureMessage, startChallenge } from "../lib/auth";
 import { useVoterStatus } from "../hooks/useVoterStatus";
 import { useEthereum } from "./EthereumContext";
 import { useLocation, useNavigate } from "remix";
@@ -55,9 +55,13 @@ export const VoterProvider: FC = ({ children }) => {
       return false;
     }
 
+    const nonce = await startChallenge();
+
     let signature: string;
     try {
-      signature = await signer.signMessage(createSignatureMessage(account));
+      signature = await signer.signMessage(
+        createSignatureMessage(account, nonce)
+      );
     } catch (e) {
       console.log("[VoterContext] Failed to sign");
       return false;
@@ -71,6 +75,7 @@ export const VoterProvider: FC = ({ children }) => {
       body: JSON.stringify({
         address: account,
         sig: signature,
+        nonce: nonce,
       }),
     });
 

--- a/web/app/lib/auth.server.ts
+++ b/web/app/lib/auth.server.ts
@@ -3,9 +3,10 @@ import { createSignatureMessage } from "./auth";
 
 export async function getAddressFromSignatureChallenge(
   address: string,
-  rcpSig: string
+  rcpSig: string,
+  nonce: string
 ) {
-  const challenge = createSignatureMessage(address);
+  const challenge = createSignatureMessage(address, nonce);
 
   const sig = utils.fromRpcSig(rcpSig);
   const hash = utils.hashPersonalMessage(Buffer.from(challenge));

--- a/web/app/lib/auth.ts
+++ b/web/app/lib/auth.ts
@@ -1,4 +1,12 @@
-export function createSignatureMessage(address: string) {
+export async function startChallenge() {
+  const res = await fetch("/api/auth/challenge");
+  if (res.ok) {
+    const json = await res.json();
+    return json.data.nonce;
+  }
+}
+
+export function createSignatureMessage(address: string, nonce: string) {
   return `
 Welcome to Votify!
 
@@ -8,5 +16,8 @@ This request will not trigger a blockchain transaction or cost any gas fees.
 
 Wallet address:
 ${address}
+
+Nonce:
+${nonce}
 `;
 }

--- a/web/app/routes/api/auth/challenge.ts
+++ b/web/app/routes/api/auth/challenge.ts
@@ -1,0 +1,18 @@
+import { LoaderFunction, json } from "remix";
+import { commitSession, getSession } from "../../../sessions";
+import crypto from "crypto";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const session = await getSession(request.headers.get("Cookie"));
+  const nonce = crypto.randomBytes(16).toString("base64");
+  session.set("nonce", nonce);
+
+  return json(
+    { success: true, data: { nonce: nonce } },
+    {
+      headers: {
+        "Set-Cookie": await commitSession(session),
+      },
+    }
+  );
+};

--- a/web/app/routes/api/auth/index.ts
+++ b/web/app/routes/api/auth/index.ts
@@ -1,25 +1,34 @@
 import { ActionFunction, json } from "remix";
-import { getAddressFromSignatureChallenge } from "../../lib/auth.server";
-import { commitSession, getSession } from "../../sessions";
+import { getAddressFromSignatureChallenge } from "../../../lib/auth.server";
+import { commitSession, getSession } from "../../../sessions";
 
 export const action: ActionFunction = async ({ request }) => {
   switch (request.method) {
     case "POST": {
+      const session = await getSession(request.headers.get("Cookie"));
       const body = await request.json();
+
+      const nonce = session.get("nonce");
+      session.unset("nonce"); // Immediately invalidate the challenge
+
+      console.log("nonce", nonce, body.nonce);
+      if (nonce == null || body.nonce == null || body.nonce !== nonce) {
+        return { success: false, error: "Challenge failed." };
+      }
 
       const derivedAddress = await getAddressFromSignatureChallenge(
         body.address,
-        body.sig
+        body.sig,
+        body.nonce
       );
 
       if (
         `0x${derivedAddress}`.toLowerCase() !==
         new String(body.address).toLowerCase()
       ) {
-        return { success: false };
+        return { success: false, error: "Signature address mismatch." };
       }
 
-      const session = await getSession(request.headers.get("Cookie"));
       session.set("address", body.address);
 
       return json(


### PR DESCRIPTION
# What it does
Adds a random value to the signature when verifying a wallet to make sure that the challenge was issued by Votify.

# How it works
When you click "Verify"
- Client starts a challenge with the server, server create a nonce and return it to the client as well as linking it to the current session (via the cookie)
- The nonce is included in the signed message
- The server knows what nonce to expect and verify that the signature and the nonce match 